### PR TITLE
Implement GBFS 2.1 Vehicle Types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     ecmaVersion: 2018,
   },
   rules: {
-    "max-len": ["error", 150]
+    "max-len": ["error", 150],
+    "no-unused-vars": ["error", {"args": "after-used"}],
   },
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "node src/index.js",
-    "serve": "nodemon -- --dashboard -v -s Velocity#https://nitro.openvelo.org/aachen/velocity/v1/gbfs.json -s Tier#https://nitro.openvelo.org/aachen/tier/v1/gbfs.json | bunyan",
+    "serve": "nodemon -- --dashboard -v -s Velocity#https://nitro.openvelo.org/aachen/velocity/v2/gbfs.json -s Tier#https://nitro.openvelo.org/aachen/tier/v2/gbfs.json | bunyan",
     "format": "eslint . --fix",
     "lint": "eslint . --max-warnings 0"
   },

--- a/src/feeds.js
+++ b/src/feeds.js
@@ -8,4 +8,5 @@ module.exports = Object.freeze({
   systemRegions: 'system_regions',
   systemPricingPlans: 'system_pricing_plans',
   systemAlerts: 'system_alerts',
+  vehicleTypes: 'vehicle_types',
 });

--- a/src/gbfs.js
+++ b/src/gbfs.js
@@ -12,11 +12,12 @@ const supportedFeeds = [
 
 const calculateVehicleBatteries = (vehicles, vehicleTypes) => vehicles.map((vehicle) => ({
   ...vehicle,
-  mia_battery: ((vehicle.current_range_meters
+  x_mia_battery: parseFloat(((vehicle.current_range_meters
     / vehicleTypes.find((vehicleType) => vehicleType.vehicle_type_id === vehicle.vehicle_type_id).max_range_meters)
     * 100
-  ),
+  ).toFixed(2)),
 }));
+
 class GBFS {
   constructor({ serviceKey, autoDiscoveryURL, pubSub }) {
     this.serviceKey = serviceKey;

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 const FEED = require('./feeds');
 
 const queryType = {
@@ -69,7 +68,7 @@ const stationBody = (name = '', feeds = []) => {
   return string;
 };
 
-const stationStatusBody = (_name = [], feeds = []) => {
+const stationStatusBody = (_name, feeds = []) => {
   let string = `
   station_id: Int!
   num_bikes_available: Int!
@@ -88,19 +87,24 @@ const stationStatusBody = (_name = [], feeds = []) => {
   return string;
 };
 
-const bikeBody = (_name = '', feeds = []) => {
-  let string = `
+const bikeBody = (_name, feeds = []) => {
+  let vehicleTypes = '';
+  if (feeds.includes(FEED.vehicleTypes)) {
+    vehicleTypes = `
+    vehicle_type_id: String
+    current_range_meters: Float
+    x_mia_battery: Float
+    `;
+  }
+  const string = `
   bike_id: String!
   lat: Float!
   lon: Float!
   is_reserved: Boolean!
   is_disabled: Boolean!
+  last_reported: Int
+  ${vehicleTypes}
   `;
-  if (feeds.includes(FEED.vehicleTypes)) {
-    string += '\nvehicle_type_id: String';
-    string += '\ncurrent_range_meters: Float';
-    string += '\nmia_battery: Float';
-  }
   return string;
 };
 
@@ -193,7 +197,7 @@ module.exports = (services) => {
     is_disabled: Boolean
     vehicle_type_id: String
     current_range_meters: Float
-    mia_battery: Float
+    x_mia_battery: Float
   }
 
   type AvailableDock {

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const FEED = require('./feeds');
 
 const queryType = {
@@ -6,7 +7,16 @@ const queryType = {
   [FEED.stationStatus]: () => '',
   [FEED.freeBikeStatus]: (name) => `bikes(with_ids: [String]): [${name}Bike]`,
   [FEED.systemAlerts]: (name) => `systemAlerts: [${name}SystemAlert]`,
+  [FEED.vehicleTypes]: (name) => `vehicleTypes: [${name}VehicleTypes]`,
 };
+
+const vehicleTypeBody = () => `
+vehicle_type_id: String
+form_factor: String
+propulsion_type: String
+max_range_meters: Int!
+name: String!
+`;
 
 const systemAlertBody = () => `
 alert_id: String!
@@ -59,25 +69,40 @@ const stationBody = (name = '', feeds = []) => {
   return string;
 };
 
-const stationStatusBody = () => `
-station_id: Int!
-num_bikes_available: Int!
-num_bikes_disabled: Int
-num_docks_available: Int!
-num_docks_disabled: Int
-is_installed: Boolean!
-is_renting: Boolean!
-is_returning: Boolean!
-last_reported: String!
-`;
+const stationStatusBody = (_name = [], feeds = []) => {
+  let string = `
+  station_id: Int!
+  num_bikes_available: Int!
+  num_bikes_disabled: Int
+  num_docks_available: Int!
+  num_docks_disabled: Int
+  is_installed: Boolean!
+  is_renting: Boolean!
+  is_returning: Boolean!
+  last_reported: Int!
+  count: Int`;
+  if (feeds.includes(FEED.vehicleTypes)) {
+    string += '\nvehicles: [DockedVehicle]';
+    string += '\nvehicle_docks_available: [AvailableDock]';
+  }
+  return string;
+};
 
-const bikeBody = () => `
-bike_id: String!
-lat: Float!
-lon: Float!
-is_reserved: Boolean!
-is_disabled: Boolean!
-`;
+const bikeBody = (_name = '', feeds = []) => {
+  let string = `
+  bike_id: String!
+  lat: Float!
+  lon: Float!
+  is_reserved: Boolean!
+  is_disabled: Boolean!
+  `;
+  if (feeds.includes(FEED.vehicleTypes)) {
+    string += '\nvehicle_type_id: String';
+    string += '\ncurrent_range_meters: Float';
+    string += '\nmia_battery: Float';
+  }
+  return string;
+};
 
 const build = (name, superClass, body, feeds) => `
 type ${name}${superClass} implements ${superClass} {
@@ -112,15 +137,17 @@ module.exports = (services) => {
     dynamicString += feeds.map((feed) => {
       switch (feed) {
         case FEED.systemInformation:
-          return build(name, 'SystemInformation', systemInformationBody);
+          return build(name, 'SystemInformation', systemInformationBody, feeds);
         case FEED.stationInformation:
           return build(name, 'Station', stationBody, feeds);
         case FEED.stationStatus:
-          return build(name, 'StationStatus', stationStatusBody);
+          return build(name, 'StationStatus', stationStatusBody, feeds);
         case FEED.freeBikeStatus:
-          return build(name, 'Bike', bikeBody);
+          return build(name, 'Bike', bikeBody, feeds);
         case FEED.systemAlerts:
-          return build(name, 'SystemAlert', systemAlertBody);
+          return build(name, 'SystemAlert', systemAlertBody, feeds);
+        case FEED.vehicleTypes:
+          return build(name, 'VehicleTypes', vehicleTypeBody, feeds);
         default:
           return '';
       }
@@ -160,6 +187,20 @@ module.exports = (services) => {
     web: String
   }
 
+  type DockedVehicle {
+    bike_id: String
+    is_reserved: Boolean
+    is_disabled: Boolean
+    vehicle_type_id: String
+    current_range_meters: Float
+    mia_battery: Float
+  }
+
+  type AvailableDock {
+    vehicle_type_ids: [String]
+    count: Int
+  }
+
   interface Station {
     ${stationBody()}
   }
@@ -180,6 +221,9 @@ module.exports = (services) => {
     ${systemAlertBody()}
   }
 
+  interface VehicleTypes {
+    ${vehicleTypeBody()}
+  }
 
   ${dynamicString}
   


### PR DESCRIPTION
This is a start to GBFS 2.1

## TODO:

 - Vehicle Types as GraphQL Enums instead of Strings
 - Check if everything is implemented correctly
 - `toFixed(0)` on any Numbers, as JavaScript floating point imprecision causes rounding errors