### PR TITLE
:sparkles: Add with_ids station filter

### DIFF
--- a/src/gbfs.js
+++ b/src/gbfs.js
@@ -67,8 +67,12 @@ class GBFS {
     }
   }
 
-  stations() {
-    return this.feedCache[FEED.stationInformation].stations || [];
+  stations(withIds = undefined) {
+    const { stations } = this.feedCache[FEED.stationInformation];
+    if (withIds !== undefined) {
+      return stations.filter((station) => withIds.includes(station.station_id));
+    }
+    return stations;
   }
 
   systemInformation() {
@@ -103,7 +107,7 @@ class GBFS {
     }
 
     if (this.feeds[FEED.stationInformation]) {
-      object.stations = () => this.stations();
+      object.stations = ({ with_ids: withIds }) => this.stations(withIds);
     }
 
     if (this.feeds[FEED.systemAlerts]) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -2,7 +2,7 @@ const FEED = require('./feeds');
 
 const queryType = {
   [FEED.systemInformation]: (name) => `systemInformation: ${name}SystemInformation`,
-  [FEED.stationInformation]: (name) => `stations: [${name}Station]`,
+  [FEED.stationInformation]: (name) => `stations(with_ids: [String]): [${name}Station]`,
   [FEED.stationStatus]: () => '',
   [FEED.freeBikeStatus]: (name) => `bikes(with_ids: [String]): [${name}Bike]`,
   [FEED.systemAlerts]: (name) => `systemAlerts: [${name}SystemAlert]`,


### PR DESCRIPTION
Similar to `bikes(with_ids: ["2xab"])`, there's now a `stations(with_ids: ["2", "56"])` which returns only stations with these station ids.